### PR TITLE
Skip ACP

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,19 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+    - completed
+
+permissions:
+  checks: read
+  contents: write
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@
 */
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useArtifactCachingProxy: false,
   configurations: [
     [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],


### PR DESCRIPTION
Needed to get a green build, for now. Alternatively, your dependencies need to be deployed to the central repository if you want to remove this skip in the future.